### PR TITLE
76 Add resolutions for testcafe and related packages in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     "webpack": "^5.42.0",
     "react-universal-component": "^4.0.0",
     "util": "0.12.3",
-    "cheerio": "1.0.0-rc.12"
+    "cheerio": "1.0.0-rc.12",
+    "testcafe": "3.7.1",
+    "testcafe-hammerhead": "24.7.2",
+    "testcafe-legacy-api": "5.1.4"
   }
 }


### PR DESCRIPTION
🔧 Fix: Lock TestCafe to `3.7.1` to Prevent `lru-cache@11.0.2` Incompatibility  

This commit locks **TestCafe** to version `3.7.1` in `package.json` to prevent dependency conflicts caused by **`lru-cache@11.0.2`**, which is incompatible with **Node.js 18** (required for MSDyn365 Commerce).  

### 🔍 Issue Reference:  
Fixes [#76](https://github.com/microsoft/Msdyn365.Commerce.Online/issues/76)  

### 🛠 Changes:
- Added `"resolutions"` to `package.json`:
  ```json
  "resolutions": {
    "testcafe": "3.7.1",
    "testcafe-hammerhead": "24.7.2",
    "testcafe-legacy-api": "5.1.4"
  }
