### PR TITLE
Update package.json for sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
     "terser": "5.5.0",
     "terser-webpack-plugin": "5.1.1",
     "process": "0.11.10",
+    "sass": "^1.85.0",
     "sass-loader": "^10.2.0",
-    "css-loader": "^2.1.1",
-    "node-sass": "^6.0.1",
+    "css-loader": "^2.1.1",   
     "mini-css-extract-plugin": "^0.5.0",
     "css-minimizer-webpack-plugin": "3.1.3",
     "ignore-emit-webpack-plugin": "2.0.6"


### PR DESCRIPTION
Replace node-sass with sass for Node.js 18+ compatibility

- node-sass has been deprecated and is no longer supported in Node.js versions 18 and above.
- Replaced node-sass with sass to ensure compatibility with Node.js 18+.
- This update aligns with the latest release (v9.52) which only supports Node.js 18+.

Fixes build issues with newer Node.js versions.