### PR TITLE
Fix @types/minimatch version to avoid node version incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "cheerio": "1.0.0-rc.12",
     "testcafe": "3.7.1",
     "testcafe-hammerhead": "24.7.2",
-    "testcafe-legacy-api": "5.1.4"
+    "testcafe-legacy-api": "5.1.4",
+    "@types/minimatch": "5.1.2"
   }
 }


### PR DESCRIPTION
Newer version of @types/minimatch 6.0.0 released 5 days ago is triggering subsequent higher version requirements for minimatch which are not supported in node 16 - 18 version.