### PR TITLE
Pinning core-internal version to 1.56.3 to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "resolutions": {
     "@msdyn365-commerce/bootloader": "^1.0.0",
     "@msdyn365-commerce/core": "^1.0.0",
+    "@msdyn365-commerce/core-internal": "1.56.3",
     "@msdyn365-commerce-modules/core-components": "^1.0.0",
     "axios": "^0.21.1",
     "@types/react": "16.9.0",


### PR DESCRIPTION
Pinning core-internal version to 1.56.3 to avoid conflicts

It was observed that the base theme and custom theme could fetch different versions of core-internal and may result in error. 