### PR TITLE
Add CI/CD pipeline for e-commerce extension package build and release

### DIFF
--- a/Pipeline/PowerShellScripts/CopyFileToDestination.ps1
+++ b/Pipeline/PowerShellScripts/CopyFileToDestination.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$RelativePath,
+    [string]$File,
+    [string]$DestinationFullName
+)
+$searchFile = Get-ChildItem -Path $RelativePath -Filter $File -Recurse
+if (-NOT $searchFile) {
+    throw "$File file was not found."
+}
+else {
+    Copy-Item $searchFile.FullName -Destination "$DestinationFullName"
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/Common/CommonFunctions.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/Common/CommonFunctions.ps1
@@ -1,0 +1,9 @@
+function Get-WhoAmI {
+    $WhoAmIRequest = @{
+        Uri     = $baseURI + 'WhoAmI'
+        Method  = 'Get'
+        Headers = $baseHeaders
+    }
+
+    Invoke-RestMethod @WhoAmIRequest
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/Common/Core.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/Common/Core.ps1
@@ -1,0 +1,128 @@
+function Connect {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $environmentUrl,
+
+        [Parameter(Mandatory)]
+        [String]
+        $tenantId,
+
+        [Parameter(Mandatory)]
+        [String]
+        $clientId,
+
+        [Parameter()]
+        [String]
+        $clientSecret,
+
+        [Parameter()]
+        [String]
+        $certificateThumbprint
+    )
+
+    if (-not $certificateThumbprint -and -not $clientSecret) {
+        throw "Either 'certificateThumbprint' or 'clientSecret' must be provided."
+    }
+
+    try {
+        # Ensure environmentUrl ends with /
+        if (-not $environmentUrl.EndsWith('/')) {
+            $environmentUrl += '/'
+        }
+
+        $tokenEndpoint = "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token"
+        Write-Host "Requesting token from $tokenEndpoint"
+
+        # Build token request body — prefer certificate over client secret
+        if ($certificateThumbprint) {
+            $cert = Get-Item "Cert:\CurrentUser\My\$certificateThumbprint" -ErrorAction SilentlyContinue
+            if (-not $cert) {
+                $cert = Get-Item "Cert:\LocalMachine\My\$certificateThumbprint" -ErrorAction SilentlyContinue
+            }
+            if (-not $cert) {
+                throw "Certificate with thumbprint '$certificateThumbprint' not found in CurrentUser or LocalMachine stores."
+            }
+
+            Write-Host "Using certificate: $($cert.Subject) ($($cert.Thumbprint), expires $($cert.NotAfter.ToString('yyyy-MM-dd')))"
+
+            $body = @{
+                client_id             = $clientId
+                client_assertion      = New-ClientAssertion -cert $cert -clientId $clientId -tokenEndpoint $tokenEndpoint
+                client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+                scope                 = "${environmentUrl}.default"
+                grant_type            = 'client_credentials'
+            }
+        }
+        else {
+            $body = @{
+                client_id     = $clientId
+                client_secret = $clientSecret
+                scope         = "${environmentUrl}.default"
+                grant_type    = 'client_credentials'
+            }
+        }
+
+        $tokenResponse = Invoke-RestMethod -Uri $tokenEndpoint `
+            -Method Post `
+            -Body $body `
+            -ContentType "application/x-www-form-urlencoded" `
+            -ErrorAction Stop
+
+        # Define common set of headers
+        $global:baseHeaders = @{
+            'Authorization'    = "Bearer $($tokenResponse.access_token)"
+            'Accept'           = 'application/json'
+            'OData-MaxVersion' = '4.0'
+            'OData-Version'    = '4.0'
+            'Content-Type'     = 'application/json; charset=utf-8'
+        }
+
+        # Set baseURI
+        $global:baseURI = "${environmentUrl}api/data/v9.2/"
+
+        Write-Host "Successfully connected to $environmentUrl" -ForegroundColor Green
+        Write-Verbose "Base URI set to: $global:baseURI"
+
+        # Return connection info (without sensitive data)
+        return @{
+            Connected    = $true
+            BaseURI      = $global:baseURI
+            TokenExpires = (Get-Date).AddSeconds($tokenResponse.expires_in)
+        }
+    }
+    catch {
+        Write-Error "Failed to connect to Dataverse: $($_.Exception.Message)"
+        throw
+    }
+}
+
+function New-ClientAssertion {
+    param (
+        [Parameter(Mandatory)]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]
+        $cert,
+
+        [Parameter(Mandatory)]
+        [String]
+        $clientId,
+
+        [Parameter(Mandatory)]
+        [String]
+        $tokenEndpoint
+    )
+
+    $x5t = [Convert]::ToBase64String($cert.GetCertHash()).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+
+    $now = [DateTimeOffset]::UtcNow
+    $header  = @{ alg = 'RS256'; typ = 'JWT'; x5t = $x5t } | ConvertTo-Json -Compress
+    $payload = @{ aud = $tokenEndpoint; iss = $clientId; sub = $clientId; jti = [Guid]::NewGuid().ToString(); nbf = $now.ToUnixTimeSeconds(); exp = $now.AddMinutes(10).ToUnixTimeSeconds() } | ConvertTo-Json -Compress
+
+    $toBase64Url = { param($bytes) [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_') }
+    $unsigned = "$(& $toBase64Url ([Text.Encoding]::UTF8.GetBytes($header))).$(& $toBase64Url ([Text.Encoding]::UTF8.GetBytes($payload)))"
+
+    $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+    $sig = $rsa.SignData([Text.Encoding]::UTF8.GetBytes($unsigned), [Security.Cryptography.HashAlgorithmName]::SHA256, [Security.Cryptography.RSASignaturePadding]::Pkcs1)
+
+    return "$unsigned.$(& $toBase64Url $sig)"
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/Operations/ExtensionPackageOperations.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/Operations/ExtensionPackageOperations.ps1
@@ -1,0 +1,180 @@
+. $PSScriptRoot\TableOperations.ps1
+. $PSScriptRoot\FileOperations.ps1
+
+function New-EcomExtensionPackage {
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PackageName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PackagePublisher,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PackageVersion,
+
+        [Parameter()]
+        [String]
+        $SdkVersion,
+
+        [Parameter()]
+        [String]
+        $SskVersion,
+
+        [Parameter()]
+        [ValidateSet('Valid', 'Invalid')]
+        [String]
+        $ValidationStatus,
+
+        [Parameter()]
+        [String]
+        $PackageDescription
+    )
+
+    try {
+        $body = @{
+            msprov_name       = $PackageName
+            msprov_publisher  = $PackagePublisher
+            msprov_version    = $PackageVersion
+            msprov_sdkversion = $SdkVersion
+            msprov_assettype  = 1 # E-Commerce Extension Package
+        }
+
+        # Store sskVersion in Additional Properties as JSON
+        if ($SskVersion) {
+            $body['msprov_additionalproperties'] = (@{ sskversion = $SskVersion } | ConvertTo-Json -Compress)
+        }
+
+        # Add optional fields if provided
+        if ($ValidationStatus) {
+            $statusValue = switch ($ValidationStatus) {
+                'Valid'   { 202570000 }
+                'Invalid' { 202570001 }
+            }
+            $body['msprov_commerceextensionasset_validationstatus'] = $statusValue
+        }
+
+        if ($PackageDescription) {
+            $body['msprov_description'] = $PackageDescription
+        }
+
+        Write-Host "Creating e-commerce extension package record: $PackageName ($PackageVersion)"
+
+        $recordId = New-Record -setName 'msprov_commerceextensionassets' -body $body
+
+        Write-Host "Successfully created e-commerce extension package record with ID: $recordId`n`n" -ForegroundColor Green
+        return $recordId
+    }
+    catch {
+        Write-Error "Failed to create e-commerce extension package record $PackageName ($PackageVersion): $($_.Exception.Message)`n`n"
+        throw
+    }
+}
+
+function Set-EcomExtensionPackageFile {
+    param (
+        [Parameter(Mandatory)]
+        [System.Guid]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Leaf })]
+        [String]
+        $FilePath,
+
+        [Parameter()]
+        [String]
+        $ColumnName = 'msprov_payload'
+    )
+
+    try {
+        $fileInfo = Get-Item -Path $FilePath
+        $fileSizeMB = [Math]::Round($fileInfo.Length / 1MB, 2)
+
+        Write-Host "Uploading e-commerce extension package file: $($fileInfo.Name) ($fileSizeMB MB)"
+
+        Set-FileColumnInChunks -setName 'msprov_commerceextensionassets' `
+            -id $PackageId `
+            -columnName $ColumnName `
+            -file $fileInfo
+
+        Write-Host "Successfully uploaded e-commerce extension package file to record: $PackageId`n`n" -ForegroundColor Green
+    }
+    catch {
+        Write-Error "Failed to upload e-commerce extension package file: $($_.Exception.Message)`n`n"
+        throw
+    }
+}
+
+function Get-EcomExtensionPackage {
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PackageName,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $PackageVersion
+    )
+
+    try {
+        Write-Host "Querying e-commerce extension package: $PackageName ($PackageVersion)"
+
+        $filter = "?`$filter=msprov_name eq '$PackageName' and msprov_version eq '$PackageVersion' and msprov_assettype eq 1"
+        $response = Get-Records -setName 'msprov_commerceextensionassets' -query $filter
+
+        $records = $response.value
+
+        if (-not $records -or $records.Count -eq 0) {
+            Write-Host "No e-commerce extension package found: $PackageName ($PackageVersion)" -ForegroundColor Yellow
+            return $null
+        }
+
+        Write-Host "Found $($records.Count) e-commerce extension package record(s): $PackageName ($PackageVersion)`n`n" -ForegroundColor Green
+        return $records
+    }
+    catch {
+        Write-Error "Failed to query e-commerce extension package $PackageName ($PackageVersion): $($_.Exception.Message)`n`n"
+        throw
+    }
+}
+
+function Get-EcomExtensionPackageFile {
+    param (
+        [Parameter(Mandatory)]
+        [System.Guid]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [String]
+        $OutputDirectory,
+
+        [Parameter()]
+        [String]
+        $ColumnName = 'msprov_payload'
+    )
+
+    try {
+        Write-Host "Downloading e-commerce extension package file from record: $PackageId"
+
+        $file = Get-FileColumnInChunks -setName 'msprov_commerceextensionassets' `
+            -id $PackageId `
+            -columnName $ColumnName `
+            -outputDirectory $OutputDirectory
+
+        Write-Host "Successfully downloaded e-commerce extension package file: $($file.Name)`n`n" -ForegroundColor Green
+        return $file
+    }
+    catch {
+        Write-Error "Failed to download e-commerce extension package file: $($_.Exception.Message)`n`n"
+        throw
+    }
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/Operations/FileOperations.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/Operations/FileOperations.ps1
@@ -1,0 +1,161 @@
+function Set-FileColumnInChunks {
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [System.Guid]
+        $id,
+
+        [Parameter(Mandatory)]
+        [string]
+        $columnName,
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [System.IO.FileInfo]
+        $file
+    )
+
+    $uri = '{0}{1}({2})' -f $baseURI, $setName, $id
+    $uri += '/{0}?x-ms-file-name={1}' -f $columnName, $file.Name
+
+    $chunkHeaders = $baseHeaders.Clone()
+    $chunkHeaders['x-ms-transfer-mode'] = 'chunked'
+
+    $InitializeChunkedFileUploadRequest = @{
+        Uri     = $uri
+        Method  = 'Patch'
+        Headers = $chunkHeaders
+    }
+
+    Invoke-RestMethod @InitializeChunkedFileUploadRequest -ResponseHeadersVariable rhv | Out-Null
+
+    $locationUri = $rhv['Location'][0]
+    $chunkSize = [int]$rhv['x-ms-chunk-size'][0]
+
+    Write-Host "Chunk size: $([Math]::Round($chunkSize / 1MB, 2)) MB"
+
+    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+    $totalChunks = [Math]::Ceiling($bytes.Length / $chunkSize)
+    $currentChunk = 0
+
+    for ($offset = 0; $offset -lt $bytes.Length; $offset += $chunkSize) {
+
+        $currentChunk++
+
+        $count = if (($offSet + $chunkSize) -gt $bytes.Length) {
+            $bytes.Length % $chunkSize
+        }
+        else {
+            $chunkSize
+        }
+
+        $lastByte = $offset + ($count - 1)
+
+        $range = 'bytes {0}-{1}/{2}' -f $offset, $lastByte, $bytes.Length
+
+        $contentHeaders = $baseHeaders.Clone()
+        $contentHeaders['Content-Range'] = $range
+        $contentHeaders['Content-Type'] = 'application/octet-stream'
+        $contentHeaders['x-ms-file-name'] = $file.Name
+
+        $UploadFileChunkRequest = @{
+            Uri     = $locationUri
+            Method  = 'Patch'
+            Headers = $contentHeaders
+            Body    = [byte[]]$bytes[$offSet..$lastByte]
+        }
+
+        Invoke-RestMethod @UploadFileChunkRequest | Out-Null
+
+        Write-Host "Uploaded chunk $currentChunk/$totalChunks"
+    }
+}
+
+function Get-FileColumnInChunks {
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [System.Guid]
+        $id,
+
+        [Parameter(Mandatory)]
+        [string]
+        $columnName,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [string]
+        $outputDirectory
+    )
+
+    $uri = '{0}{1}({2})/{3}/$value' -f $baseURI, $setName, $id, $columnName
+
+    $chunkSize = 4 * 1024 * 1024  # 4 MB
+
+    # Use minimal headers for file download (OData headers cause 400 on file endpoints)
+    $downloadHeaders = @{
+        'Authorization' = $baseHeaders['Authorization']
+        'Range'         = 'bytes=0-{0}' -f ($chunkSize - 1)
+    }
+
+    $InitialDownloadRequest = @{
+        Uri     = $uri
+        Method  = 'Get'
+        Headers = $downloadHeaders
+    }
+
+    $response = Invoke-WebRequest @InitialDownloadRequest
+
+    $fileName = $response.Headers['x-ms-file-name'][0]
+    $fileSize = [long]$response.Headers['x-ms-file-size'][0]
+
+    Write-Host "Downloading file: $fileName ($([Math]::Round($fileSize / 1MB, 2)) MB)"
+    Write-Host "Chunk size: $([Math]::Round($chunkSize / 1MB, 2)) MB"
+
+    $totalChunks = [Math]::Ceiling($fileSize / $chunkSize)
+    $currentChunk = 1
+
+    $fileBytes = [System.Collections.Generic.List[byte]]::new([int]$fileSize)
+    $fileBytes.AddRange([byte[]]$response.Content)
+
+    Write-Host "Downloaded chunk $currentChunk/$totalChunks"
+
+    $offset = $response.Content.Length
+
+    while ($offset -lt $fileSize) {
+
+        $currentChunk++
+
+        $lastByte = [Math]::Min($offset + $chunkSize - 1, $fileSize - 1)
+
+        $chunkHeaders = @{
+            'Authorization' = $baseHeaders['Authorization']
+            'Range'         = 'bytes={0}-{1}' -f $offset, $lastByte
+        }
+
+        $DownloadChunkRequest = @{
+            Uri     = $uri
+            Method  = 'Get'
+            Headers = $chunkHeaders
+        }
+
+        $response = Invoke-WebRequest @DownloadChunkRequest
+
+        $fileBytes.AddRange([byte[]]$response.Content)
+        $offset += $response.Content.Length
+
+        Write-Host "Downloaded chunk $currentChunk/$totalChunks"
+    }
+
+    $outputFilePath = Join-Path $outputDirectory $fileName
+    [System.IO.File]::WriteAllBytes($outputFilePath, $fileBytes.ToArray())
+
+    Write-Host "File saved to: $outputFilePath"
+
+    return Get-Item $outputFilePath
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/Operations/TableOperations.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/Operations/TableOperations.ps1
@@ -1,0 +1,137 @@
+function Get-Records {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [String]
+        $query
+    )
+
+    $uri = $baseURI + $setName + $query
+
+    # Header for GET operations that have annotations
+    $getHeaders = $baseHeaders.Clone()
+    $getHeaders.Add('If-None-Match', $null)
+    $getHeaders.Add('Prefer', 'odata.include-annotations="*"')
+
+    $RetrieveMultipleRequest = @{
+        Uri     = $uri
+        Method  = 'Get'
+        Headers = $getHeaders
+    }
+
+    Invoke-RestMethod @RetrieveMultipleRequest
+}
+
+function New-Record {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $body
+    )
+
+    $postHeaders = $baseHeaders.Clone()
+
+    $CreateRequest = @{
+        Uri     = $baseURI + $setName
+        Method  = 'Post'
+        Headers = $postHeaders
+        Body    = ConvertTo-Json $body
+    }
+
+    Invoke-RestMethod @CreateRequest -ResponseHeadersVariable rh | Out-Null
+    $url = $rh['OData-EntityId']
+    $selectedString = Select-String -InputObject $url -Pattern '(?<=\().*?(?=\))'
+    return [System.Guid]::New($selectedString.Matches.Value.ToString())
+}
+
+function Get-Record {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [Guid]
+        $id,
+
+        [String]
+        $query
+    )
+
+    $uri = $baseURI + $setName
+    $uri = $uri + '(' + $id.Guid + ')' + $query
+
+    $getHeaders = $baseHeaders.Clone()
+    $getHeaders.Add('If-None-Match', $null)
+    $getHeaders.Add('Prefer', 'odata.include-annotations="*"')
+
+    $RetrieveRequest = @{
+        Uri     = $uri
+        Method  = 'Get'
+        Headers = $getHeaders
+    }
+
+    Invoke-RestMethod @RetrieveRequest
+}
+
+function Update-Record {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [Guid]
+        $id,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $body
+    )
+
+    $uri = $baseURI + $setName
+    $uri = $uri + '(' + $id.Guid + ')'
+
+    # Header for Update operations
+    $updateHeaders = $baseHeaders.Clone()
+    $updateHeaders.Add('If-Match', '*') # Prevent Create
+
+    $UpdateRequest = @{
+        Uri     = $uri
+        Method  = 'Patch'
+        Headers = $updateHeaders
+        Body    = ConvertTo-Json $body
+    }
+
+    Invoke-RestMethod @UpdateRequest
+}
+
+function Remove-Record {
+    param (
+        [Parameter(Mandatory)]
+        [String]
+        $setName,
+
+        [Parameter(Mandatory)]
+        [Guid]
+        $id
+    )
+
+    $uri = $baseURI + $setName
+    $uri = $uri + '(' + $id.Guid + ')'
+
+    $DeleteRequest = @{
+        Uri     = $uri
+        Method  = 'Delete'
+        Headers = $baseHeaders
+    }
+
+    Invoke-RestMethod @DeleteRequest
+}

--- a/Pipeline/PowerShellScripts/DataverseClient/UploadExtensionPackage.ps1
+++ b/Pipeline/PowerShellScripts/DataverseClient/UploadExtensionPackage.ps1
@@ -1,0 +1,184 @@
+<#
+.SYNOPSIS
+    Uploads an e-commerce extension package to Dataverse.
+
+.DESCRIPTION
+    Connects to the specified Dataverse environment, reads package metadata from
+    the zip filename (name and version), creates an e-commerce extension package
+    record in the same table as CSU packages (msprov_commerceextensionassets)
+    with asset type 1, and uploads the zip file in chunked mode.
+
+.PARAMETER PackageFilePath
+    Full path to the e-commerce extension package zip file (e.g. Msdyn365.Commerce.Online-1.0.0.zip).
+
+.PARAMETER EnvironmentUrl
+    The Dataverse environment URL (e.g., https://myorg.crm.dynamics.com/).
+
+.PARAMETER TenantId
+    Azure AD tenant ID.
+
+.PARAMETER ClientId
+    Azure AD application (client) ID.
+
+.PARAMETER ClientSecret
+    Azure AD application client secret. Required if CertificateThumbprint is not provided.
+
+.PARAMETER CertificateThumbprint
+    Thumbprint of a certificate for authentication. Preferred over ClientSecret when both are provided.
+
+.PARAMETER PackageName
+    Optional override for the package name. If not provided, it is extracted from the zip filename or package.json.
+
+.PARAMETER ValidationStatus
+    Validation status to stamp on the package record. Valid values: 'Valid', 'Invalid'.
+    Defaults to 'Valid'.
+#>
+param (
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Leaf })]
+    [String]
+    $PackageFilePath,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [String]
+    $EnvironmentUrl,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [String]
+    $TenantId,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [String]
+    $ClientId,
+
+    [Parameter()]
+    [String]
+    $ClientSecret,
+
+    [Parameter()]
+    [String]
+    $CertificateThumbprint,
+
+    [Parameter()]
+    [String]
+    $PackageName,
+
+    [Parameter()]
+    [String]
+    $PackagePublisher,
+
+    [ValidateSet('Valid', 'Invalid')]
+    [String]
+    $ValidationStatus = 'Valid'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Starting e-commerce extension package upload...`n`n"
+
+# ── Load Dataverse client modules ────────────────────────────────────────────
+. $PSScriptRoot\Common\Core.ps1
+. $PSScriptRoot\Common\CommonFunctions.ps1
+. $PSScriptRoot\Operations\ExtensionPackageOperations.ps1
+
+# ── Resolve package metadata ─────────────────────────────────────────────────
+$packageFile = Get-Item $PackageFilePath
+
+if ($packageFile.Extension -ne '.zip') {
+    throw "PackageFilePath must be a .zip file. Got: $PackageFilePath"
+}
+
+# Extract package name and version from zip filename (e.g. Msdyn365.Commerce.Online-1.0.0.zip)
+# Also try pattern with underscore from build pipeline (e.g. Msdyn365.Commerce.Online_20260401.1.zip)
+if ($packageFile.BaseName -match '^(.+)-(\d+\.\d+\.\d+.*)$') {
+    if (-not $PackageName) { $PackageName = $Matches[1] }
+    $packageVersion = $Matches[2]
+}
+elseif ($packageFile.BaseName -match '^(.+)_(.+)$') {
+    if (-not $PackageName) { $PackageName = $Matches[1] }
+    $packageVersion = $Matches[2]
+}
+else {
+    if (-not $PackageName) { $PackageName = $packageFile.BaseName }
+    $packageVersion = '1.0.0'
+    Write-Host "Could not parse version from filename, defaulting to 1.0.0" -ForegroundColor Yellow
+}
+
+# Try to extract version.json from the zip for SDK version info
+$sdkVersion = ''
+$tempDir = Join-Path $env:TEMP "ecom_pkg_$(Get-Date -Format 'yyyyMMddHHmmss')"
+try {
+    Expand-Archive -Path $packageFile.FullName -DestinationPath $tempDir -Force
+
+    $versionJsonPath = Join-Path $tempDir 'version.json'
+    if (Test-Path $versionJsonPath) {
+        $versionInfo = Get-Content $versionJsonPath -Raw | ConvertFrom-Json
+        $sdkVersion = $versionInfo.sdkVersion
+        $sskVersion = $versionInfo.sskVersion
+    }
+
+    $packageJsonPath = Join-Path $tempDir 'package.json'
+    if (Test-Path $packageJsonPath) {
+        $packageInfo = Get-Content $packageJsonPath -Raw | ConvertFrom-Json
+        if (-not $PackageName -and $packageInfo.name) { $PackageName = $packageInfo.name }
+        if ($packageInfo.version) { $packageVersion = $packageInfo.version }
+        if (-not $PackagePublisher -and $packageInfo.author) { $PackagePublisher = $packageInfo.author }
+    }
+}
+catch {
+    Write-Host "Could not extract metadata from package zip: $($_.Exception.Message)" -ForegroundColor Yellow
+}
+finally {
+    if (Test-Path $tempDir) {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "Package file: $($packageFile.Name) ($([Math]::Round($packageFile.Length / 1MB, 2)) MB)"
+
+if ($packageFile.Length -gt 1GB) {
+    throw "Package file size exceeds 1 GB limit"
+}
+
+if (-not $PackagePublisher) {
+    throw "PackagePublisher must be provided either as a parameter or via the 'author' field in package.json"
+}
+
+Write-Host "Package info:"
+Write-Host "  Name:        $PackageName"
+Write-Host "  Publisher:   $PackagePublisher"
+Write-Host "  Version:     $packageVersion"
+Write-Host "  SDK Version: $sdkVersion"
+Write-Host "  SSK Version: $sskVersion"
+Write-Host "`n"
+
+# ── Connect to Dataverse ─────────────────────────────────────────────────────
+$connectParams = @{
+    environmentUrl = $EnvironmentUrl
+    tenantId       = $TenantId
+    clientId       = $ClientId
+}
+if ($CertificateThumbprint) { $connectParams.certificateThumbprint = $CertificateThumbprint }
+elseif ($ClientSecret)      { $connectParams.clientSecret = $ClientSecret }
+
+Connect @connectParams | Out-Null
+
+Write-Host "Connected as: $((Get-WhoAmI).UserId)`n`n"
+
+# ── Create package record and upload file ────────────────────────────────────
+$params = @{
+    PackageName      = $PackageName
+    PackagePublisher = $PackagePublisher
+    PackageVersion   = $packageVersion
+    SdkVersion       = $sdkVersion
+    SskVersion       = $sskVersion
+    ValidationStatus = $ValidationStatus
+}
+
+$packageId = New-EcomExtensionPackage @params
+Set-EcomExtensionPackageFile -PackageId $packageId -FilePath $packageFile.FullName
+
+Write-Host "SUCCESS: E-commerce extension package uploaded - $PackageName ($packageVersion)`n`n" -ForegroundColor Green

--- a/Pipeline/README.md
+++ b/Pipeline/README.md
@@ -1,0 +1,111 @@
+# E-Commerce Extension — Azure DevOps Pipelines
+
+This folder contains the Azure DevOps (ADO) pipeline definitions and supporting scripts to **build**, **pack**, and **upload** a Dynamics 365 Commerce e-commerce extension package to Dataverse.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| **Azure DevOps project** | An ADO project with access to create pipelines and variable groups. |
+| **Azure AD App Registration** | An app registration with a client secret (or certificate). This is used for OAuth2 client-credentials authentication to Dataverse. |
+| **Dataverse Application User** | The app registration must be added as an Application User in the target Dataverse environment with permissions to write to the `msprov_commerceextensionassets` table. |
+| **Node.js 20.x** | The build pipeline uses Node.js 20.x (installed automatically by the pipeline). |
+
+## Setup Instructions
+
+### 1. Clone or fork this repository
+
+Clone this repo into your own ADO project:
+
+```
+git clone <your-ado-repo-url>
+```
+
+### 2. Update `package.json`
+
+Open `package.json` in the repo root and update these fields to match your project:
+
+| Field | Example | Purpose |
+|---|---|---|
+| `name` | `Contoso.Commerce.Online` | Becomes the package name in Dataverse. |
+| `version` | `1.0.0` | Package version stored in Dataverse. |
+
+### 3. Create the Build Pipeline
+
+1. In ADO, go to **Pipelines → New Pipeline**.
+2. Select your repository and choose **Existing Azure Pipelines YAML file**.
+3. Select the path: `Pipeline/YAML_Files/build-pipeline.yml`.
+4. **Name the pipeline**: `Commerce-ECommerce-Extension-Build`.
+
+> **Important:** The release pipeline references the build pipeline by name. If you choose a different name, update the `source` field in `release-pipeline.yml` to match.
+
+#### What the build pipeline does
+
+| Step | Description |
+|---|---|
+| Install Node.js 20.x | Sets up the Node runtime. |
+| Install Yarn | Installs Yarn globally via npm. |
+| `yarn install` | Installs all dependencies. |
+| `yarn build` | Compiles the e-commerce application. |
+| `yarn msdyn365 pack` | Packages the application into a `.zip` file. |
+| Copy & Publish | Renames the zip with the build number and publishes it as a build artifact. |
+
+### 4. Create the Variable Group
+
+Go to **Pipelines → Library** and create a variable group named:
+
+```
+Commerce-ECommerce-Extension-Release-Variables
+```
+
+Add the following variables:
+
+| Variable | Required | Description |
+|---|---|---|
+| `DataverseUrl` | Yes | Your Dataverse environment URL (e.g., `https://myorg.crm.dynamics.com/`). |
+| `TenantId` | Yes | Azure AD tenant ID. |
+| `ClientId` | Yes | Azure AD app registration client ID. |
+| `ClientSecret` | Yes | App registration client secret. **Mark as secret** in the variable group. |
+| `PackagePublisher` | Yes | Publisher name for the package in Dataverse (e.g., `Contoso`). |
+| `PackageName` | No | Optional override for the package name. If empty, the name is read from `package.json` inside the zip. |
+
+> If you rename the variable group, update the `group` field in `release-pipeline.yml` to match.
+
+### 5. Create the Release Pipeline
+
+1. In ADO, go to **Pipelines → New Pipeline**.
+2. Select your repository and choose **Existing Azure Pipelines YAML file**.
+3. Select the path: `Pipeline/YAML_Files/release-pipeline.yml`.
+4. **Name the pipeline**: `Commerce-ECommerce-Extension-Release`.
+
+#### What the release pipeline does
+
+| Step | Description |
+|---|---|
+| Download artifact | Downloads the `.zip` produced by the build pipeline. |
+| Upload to Dataverse | Extracts metadata (name, version, SDK version, SSK version) from the zip and creates a record in the `msprov_commerceextensionassets` table with asset type **E-Commerce (1)**. Then uploads the zip file in chunked mode. |
+
+### 6. Run the Pipelines
+
+1. **Run the build pipeline** first. It will produce a build artifact containing the packaged zip.
+2. **Run the release pipeline**. It will download the artifact from the latest (or selected) build and upload it to Dataverse.
+
+## How Package Metadata Is Resolved
+
+The upload script (`UploadExtensionPackage.ps1`) resolves package metadata in this order:
+
+| Field | Resolution Order |
+|---|---|
+| **Name** | `PackageName` variable (if set) → `package.json` `name` field → zip filename |
+| **Version** | `package.json` `version` field → zip filename |
+| **Publisher** | `PackagePublisher` variable (from variable group) |
+| **SDK Version** | `version.json` `sdkVersion` field inside the zip |
+| **SSK Version** | `version.json` `sskVersion` field inside the zip (stored in Additional Properties) |
+
+## Customization
+
+- **Change the package name**: Update `name` in `package.json`, or set the `PackageName` variable in the variable group to override it.
+- **Change Node.js version**: Edit the `nodeVersion` variable in `build-pipeline.yml`.
+- **Use certificate auth instead of secret**: Add a `CertificateThumbprint` variable to the variable group and update the release YAML to pass it instead of `ClientSecret`.
+- **Auto-trigger release on build completion**: Change `trigger: none` to `trigger: true` under the `resources.pipelines` section in `release-pipeline.yml`.
+- **Auto-trigger build on commit**: Change `trigger: none` to a branch filter (e.g., `trigger: [main]`) in `build-pipeline.yml`.

--- a/Pipeline/YAML_Files/build-pipeline.yml
+++ b/Pipeline/YAML_Files/build-pipeline.yml
@@ -1,0 +1,53 @@
+pr: none
+trigger: none
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  - name: nodeVersion
+    value: '20.x'
+
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node.js $(nodeVersion)'
+    inputs:
+      versionSpec: $(nodeVersion)
+
+  - task: PowerShell@2
+    displayName: 'Install Yarn'
+    inputs:
+      targetType: 'inline'
+      script: npm install -g yarn
+
+  - task: PowerShell@2
+    displayName: 'Install dependencies'
+    inputs:
+      targetType: 'inline'
+      script: yarn install
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: PowerShell@2
+    displayName: 'Build application'
+    inputs:
+      targetType: 'inline'
+      script: yarn build
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: PowerShell@2
+    displayName: 'Pack e-commerce application'
+    inputs:
+      targetType: 'inline'
+      script: yarn msdyn365 pack
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: PowerShell@2
+    displayName: 'Copy package to artifact staging directory'
+    inputs:
+      targetType: filePath
+      filePath: ./Pipeline/PowerShellScripts/CopyFileToDestination.ps1
+      arguments: '-RelativePath "$(Build.SourcesDirectory)" -File "Msdyn365.Commerce.Online-*.zip" -DestinationFullName "$(Build.ArtifactStagingDirectory)\Msdyn365.Commerce.Online_$(Build.BuildNumber).zip"'
+      failOnStderr: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'

--- a/Pipeline/YAML_Files/release-pipeline.yml
+++ b/Pipeline/YAML_Files/release-pipeline.yml
@@ -1,0 +1,51 @@
+trigger: none
+pr: none
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  - group: Commerce-ECommerce-Extension-Release-Variables
+  - name: scriptsPath
+    value: '$(Build.SourcesDirectory)/Pipeline/PowerShellScripts/DataverseClient'
+
+resources:
+  pipelines:
+    - pipeline: buildArtifact
+      source: 'Commerce-ECommerce-Extension-Build' # Must match the ADO pipeline name created from build-pipeline.yml
+      trigger: none
+
+steps:
+  - download: buildArtifact
+    artifact: drop
+    displayName: 'Download E-Commerce Extension Package'
+
+  - task: PowerShell@2
+    displayName: 'Upload E-Commerce Extension Package to Dataverse'
+    inputs:
+      targetType: 'inline'
+      pwsh: true
+      script: |
+        $ErrorActionPreference = 'Stop'
+
+        $packageFile = Get-ChildItem "$(Pipeline.Workspace)/buildArtifact/drop/Msdyn365.Commerce.Online_*.zip" | Select-Object -First 1
+
+        if (-not $packageFile) {
+            throw "No package file found"
+        }
+
+        $uploadParams = @{
+            PackageFilePath  = $packageFile.FullName
+            PackagePublisher = '$(PackagePublisher)'
+            EnvironmentUrl   = '$(DataverseUrl)'
+            TenantId         = '$(TenantId)'
+            ClientId         = '$(ClientId)'
+            ClientSecret     = '$(ClientSecret)'
+            ValidationStatus = 'Valid'
+        }
+
+        if ('$(PackageName)') {
+            $uploadParams.PackageName = '$(PackageName)'
+        }
+
+        & $(scriptsPath)/UploadExtensionPackage.ps1 @uploadParams


### PR DESCRIPTION
Add Azure DevOps build and release pipelines with PowerShell scripts to automate the generation and upload of Dynamics 365 Commerce e-commerce extension packages to Dataverse.

- Build pipeline: installs dependencies, builds, packs, and publishes artifact
- Release pipeline: downloads artifact and uploads to Dataverse
- PowerShell scripts for Dataverse authentication, chunked file upload, and extension package management via OData REST APIs
- README with setup instructions and prerequisites