### PR TITLE
[10.0.48] Add node-releases resolution to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@azure/core-auth": "1.5.0",
     "@azure/core-util": "1.5.0",
     "typescript": "4.2.4",
-    "tslib": "2.8.1"
+    "tslib": "2.8.1",
+    "node-releases": "2.0.44"
   }
 }


### PR DESCRIPTION
The node-releases package (a transitive dependency @msdyn365-commerce/bootloader -> webpack -> browserslist -> node-releases) published versions beyond 2.0.44 that dropped support for Node.js
<18. 
Since the repo supports node 16 and we do not pin this transitive dependency, yarn resolves to a newer incompatible version, causing the install to fail with error:
 `node-releases@2.0.46: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.16.0"
error Found incompatible module. `

