### PR TITLE
Pin @mapbox/jsonlint-lines-primitives to 2.0.2 (fix Node engine build failure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@azure/core-util": "1.5.0",
     "typescript": "4.2.4",
     "tslib": "2.8.1",
-    "node-releases": "2.0.44"
+    "node-releases": "2.0.44",
+    "@mapbox/jsonlint-lines-primitives": "2.0.2"
   }
 }


### PR DESCRIPTION
## Problem
yarn install fails on Node 16/18 (used by e-commerce/CSU 10.0.48 builds):

```
error @mapbox/jsonlint-lines-primitives@2.0.3: The engine `node` is incompatible with this module. Expected version `>= 22`. Got "18.20.8"
error Found incompatible module.
```

## Root cause
`@mapbox/jsonlint-lines-primitives` is a **transitive** dependency (via the Azure Maps module):

```
starter-pack -> @msdyn365-commerce-modules/azure-maps ("azure-maps-control": "^3.5.0")
  -> azure-maps-control@3.7.4 -> @maplibre/maplibre-gl-style-spec@^20 -> @mapbox/jsonlint-lines-primitives@~2.0.2
```

mapbox published `2.0.3` which added `engines: node >= 22`. The `~2.0.2` range now resolves to `2.0.3`. Since `yarn.lock` is gitignored in this repo, every build resolves fresh and picks `2.0.3` -> fails on Node 16/18.

## Fix
Pin the transitive dependency to the last Node 16/18-compatible release (`2.0.2`, `engines: node >= 0.6`) via `resolutions`.

## Validation
Verified on **Node 16.20.2**: `yarn install`, `yarn build`, and `yarn start` (dev server HTTP 200) all run cleanly.

> Note: full Node 18 support additionally requires upgrading `node-sass@6.0.1` (unsupported on Node 18) — tracked separately.
